### PR TITLE
new feature: add waybackurls-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 Production-ready, Dockerized MCP (Model Context Protocol) servers for offensive security tools. Enable AI assistants like Claude to perform security assessments, vulnerability scanning, and binary analysis.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/MCPs-24-brightgreen" alt="24 MCPs"/>
-  <img src="https://img.shields.io/badge/Tools-150+-orange" alt="150+ Tools"/>
+  <img src="https://img.shields.io/badge/MCPs-25-brightgreen" alt="25 MCPs"/>
+  <img src="https://img.shields.io/badge/Tools-153+-orange" alt="153+ Tools"/>
   <img src="https://img.shields.io/badge/Docker-Ready-blue" alt="Docker Ready"/>
 </p>
 
 ## Features
 
-- **24 MCP Servers** covering reconnaissance, web security, binary analysis, cloud security, OSINT, Active Directory, and more
-- **100+ Security Tools** accessible via natural language through Claude or other MCP clients
+- **25 MCP Servers** covering reconnaissance, web security, binary analysis, cloud security, OSINT, Active Directory, and more
+- **153+ Security Tools** accessible via natural language through Claude or other MCP clients
 - **Production Hardened** - Non-root containers, minimal images, Trivy-scanned
 - **Docker Compose** orchestration for multi-tool workflows
 - **CI/CD Ready** with GitHub Actions for automated builds and security scanning
@@ -77,7 +77,7 @@ Add to your Claude Desktop configuration:
 | [whatweb-mcp](./reconnaissance/whatweb-mcp) | 5 | Web technology fingerprinting and CMS detection |
 | [masscan-mcp](./reconnaissance/masscan-mcp) | 6 | High-speed port scanning for large networks |
 
-### Web Security (5 servers)
+### Web Security (6 servers)
 
 | Server | Tools | Description |
 |--------|-------|-------------|
@@ -85,6 +85,7 @@ Add to your Claude Desktop configuration:
 | [sqlmap-mcp](./web-security/sqlmap-mcp) | 8 | SQL injection detection and exploitation |
 | [nikto-mcp](./web-security/nikto-mcp) | - | Wrapper for [Nikto MCP](https://github.com/nittolese/nikto_mcp) web server scanner |
 | [ffuf-mcp](./web-security/ffuf-mcp) | 9 | Web fuzzing for directories, files, parameters, and virtual hosts |
+| [waybackurls-mcp](./web-security/waybackurls-mcp) | 3 | Fetch historical URLs from Wayback Machine for reconnaissance |
 | [burp-mcp](./web-security/burp-mcp) | - | Wrapper for [official Burp Suite MCP](https://github.com/PortSwigger/mcp-server) |
 
 ### Binary Analysis (6 servers)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,6 +266,32 @@ services:
           cpus: '2'
           memory: 1G
 
+  waybackurls-mcp:
+    build:
+      context: ./web-security/waybackurls-mcp
+      dockerfile: Dockerfile
+    image: ghcr.io/fuzzinglabs/waybackurls-mcp:latest
+    container_name: waybackurls-mcp
+    environment:
+      - WAYBACKURLS_OUTPUT_DIR=/app/output
+      - WAYBACKURLS_TIMEOUT=${WAYBACKURLS_TIMEOUT:-300}
+    volumes:
+      - waybackurls-output:/app/output
+    ports:
+      - "3020:3000"
+    networks:
+      - mcp-network
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+
   # ===========================================================================
   # Exploitation
   # ===========================================================================
@@ -637,4 +663,8 @@ volumes:
   capa-output:
     driver: local
   capa-samples:
+    driver: local
+
+  # Waybackurls
+  waybackurls-output:
     driver: local

--- a/web-security/waybackurls-mcp/Dockerfile
+++ b/web-security/waybackurls-mcp/Dockerfile
@@ -1,0 +1,52 @@
+# Waybackurls MCP Server
+# Fetch all URLs that the Wayback Machine knows about for a domain
+
+FROM python:3.12-alpine
+
+LABEL org.opencontainers.image.source="https://github.com/FuzzingLabs/offensive-security-mcps"
+LABEL org.opencontainers.image.description="Waybackurls MCP Server - Wayback Machine URL fetcher"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Security: Create non-root user
+RUN addgroup -g 1000 mcpuser && \
+    adduser -D -u 1000 -G mcpuser mcpuser
+
+RUN apk add --no-cache \
+    ca-certificates \
+    tini \
+    curl \
+    git \
+    go \
+    && rm -rf /var/cache/apk/*
+
+# Install waybackurls
+RUN go install github.com/tomnomnom/waybackurls@latest && \
+    mv /root/go/bin/waybackurls /usr/local/bin/waybackurls && \
+    chmod +x /usr/local/bin/waybackurls && \
+    rm -rf /root/go
+
+# Verify waybackurls installation
+RUN waybackurls --help || echo "waybackurls installed"
+
+WORKDIR /app
+
+COPY --chown=mcpuser:mcpuser requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --chown=mcpuser:mcpuser . .
+
+RUN mkdir -p /app/output && chown -R mcpuser:mcpuser /app
+
+USER mcpuser
+
+# Environment variables
+ENV WAYBACKURLS_OUTPUT_DIR=/app/output
+ENV WAYBACKURLS_TIMEOUT=300
+ENV PYTHONUNBUFFERED=1
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+    CMD pgrep -f "python.*server.py" > /dev/null || exit 1
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["python", "server.py"]

--- a/web-security/waybackurls-mcp/README.md
+++ b/web-security/waybackurls-mcp/README.md
@@ -1,0 +1,202 @@
+# Waybackurls MCP Server
+
+A Model Context Protocol server that fetches URLs from the Wayback Machine using [waybackurls](https://github.com/tomnomnom/waybackurls) by @tomnomnom.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `fetch_wayback_urls` | Fetch all archived URLs for a domain from the Wayback Machine |
+| `get_fetch_results` | Retrieve results from a previous fetch |
+| `list_active_fetches` | Show currently running fetches |
+
+## Features
+
+- **Historical URL Discovery**: Find all URLs that were ever archived for a domain
+- **Subdomain Support**: Optionally include or exclude subdomains
+- **Statistics**: Automatic analysis of discovered URLs (extensions, subdomains, path depth)
+- **Timestamp Support**: Show when URLs were archived (optional)
+- **Efficient Storage**: Results are cached and can be retrieved later
+
+## Use Cases
+
+- **Reconnaissance**: Discover old endpoints and paths that may still exist
+- **Asset Discovery**: Find forgotten subdomains and resources
+- **Attack Surface Mapping**: Identify historical attack vectors
+- **Content Discovery**: Locate archived files and directories
+- **API Enumeration**: Find old API endpoints that may still be active
+
+## Docker
+
+### Build
+
+```bash
+docker build -t waybackurls-mcp .
+```
+
+### Run
+
+```bash
+docker run --rm -i waybackurls-mcp
+```
+
+### With persistent storage
+
+```bash
+docker run --rm -i \
+  -v /path/to/output:/app/output \
+  waybackurls-mcp
+```
+
+## Claude Desktop Configuration
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "waybackurls": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "waybackurls-mcp"]
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WAYBACKURLS_OUTPUT_DIR` | `/app/output` | Results directory |
+| `WAYBACKURLS_TIMEOUT` | `300` | Default timeout (seconds) |
+| `WAYBACKURLS_MAX_CONCURRENT` | `3` | Max concurrent fetches |
+
+## Example Usage
+
+### Basic URL fetch
+
+```
+Fetch wayback machine URLs for example.com
+```
+
+### With subdomains
+
+```
+Fetch wayback URLs for example.com including all subdomains
+```
+
+### Exclude subdomains
+
+```
+Fetch wayback URLs for example.com but exclude subdomains
+```
+
+### With timestamps
+
+```
+Fetch wayback URLs for example.com with archive dates
+```
+
+### Get previous results
+
+```
+Get the results of fetch abc12345 with URLs included
+```
+
+## Tool Details
+
+### fetch_wayback_urls
+
+Fetches all URLs from the Wayback Machine for a given domain.
+
+**Parameters:**
+- `domain` (required): Domain to fetch URLs for (e.g., example.com)
+- `get_subs`: Also fetch subdomains (*.example.com)
+- `no_subs`: Don't include subdomains, only exact domain
+- `dates`: Show timestamps for when URLs were archived
+- `include_urls`: Include actual URLs in response (default: true)
+- `limit`: Maximum URLs to return (default: 100)
+- `timeout`: Timeout in seconds (default: 300)
+
+**Returns:**
+- `fetch_id`: Unique identifier for this fetch
+- `domain`: Domain that was fetched
+- `status`: completed, running, failed, timeout, or error
+- `total_urls`: Total number of URLs found
+- `stats`: URL analysis including:
+  - Extensions breakdown
+  - Subdomains breakdown
+  - Path depth distribution
+  - HTTP vs HTTPS count
+  - URLs with parameters count
+- `urls`: Array of discovered URLs (if include_urls=true)
+
+### get_fetch_results
+
+Retrieve results from a previous fetch.
+
+**Parameters:**
+- `fetch_id` (required): Fetch ID from a previous operation
+- `include_urls`: Include URLs in response
+- `limit`: Maximum URLs to return
+
+### list_active_fetches
+
+Lists currently running fetches with their start times.
+
+## Statistics
+
+The server automatically analyzes discovered URLs and provides:
+
+- **By Extension**: Count of URLs by file type (php, html, js, etc.)
+- **By Subdomain**: Distribution of URLs across subdomains
+- **By Path Depth**: How deep URLs are nested
+- **Protocols**: HTTP vs HTTPS breakdown
+- **Parameters**: Count of URLs with query parameters
+
+## Security Notice
+
+Waybackurls fetches publicly available data from the Internet Archive's Wayback Machine. This tool is designed for reconnaissance and OSINT activities. Always ensure you have permission to test the targets you discover.
+
+## Common Patterns
+
+### Finding old admin panels
+
+```
+Fetch wayback URLs for target.com and look for admin, login, or dashboard paths
+```
+
+### Discovering API endpoints
+
+```
+Fetch wayback URLs for api.example.com to find historical API routes
+```
+
+### Subdomain enumeration
+
+```
+Fetch wayback URLs for example.com with subdomains enabled
+```
+
+## Tips
+
+1. **Large domains**: May return thousands of URLs and take several minutes
+2. **Timeout**: Increase timeout for large domains (e.g., 600 seconds)
+3. **Filtering**: Use the statistics to identify interesting URL patterns
+4. **Subdomains**: Enable `get_subs` to discover forgotten subdomains
+5. **Timestamps**: Use `dates=true` to see when content was archived
+
+## Limitations
+
+- Depends on what the Wayback Machine has archived
+- Some domains may have robots.txt blocking archival
+- Rate limited by the Wayback Machine API
+- Very large domains may take significant time
+
+## Credit
+
+This MCP server wraps the excellent [waybackurls](https://github.com/tomnomnom/waybackurls) tool by [@tomnomnom](https://twitter.com/tomnomnom).
+
+## License
+
+MIT

--- a/web-security/waybackurls-mcp/requirements.txt
+++ b/web-security/waybackurls-mcp/requirements.txt
@@ -1,0 +1,3 @@
+mcp>=1.0.0
+pydantic>=2.0.0
+pydantic-settings>=2.0.0

--- a/web-security/waybackurls-mcp/server.py
+++ b/web-security/waybackurls-mcp/server.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""
+Waybackurls MCP Server
+
+A Model Context Protocol server that fetches all URLs from the Wayback Machine
+for a given domain using waybackurls by @tomnomnom.
+
+Tools:
+    - fetch_wayback_urls: Fetch URLs for a domain from the Wayback Machine
+    - get_fetch_results: Retrieve results from a previous fetch
+    - list_active_fetches: Show currently running fetches
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    Resource,
+    TextContent,
+    Tool,
+)
+from pydantic import BaseModel, Field, ConfigDict
+from pydantic_settings import BaseSettings
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("waybackurls-mcp")
+
+
+class Settings(BaseSettings):
+    """Server configuration from environment variables."""
+
+    model_config = ConfigDict(env_prefix="WAYBACKURLS_")
+
+    output_dir: str = Field(default="/app/output", alias="WAYBACKURLS_OUTPUT_DIR")
+    default_timeout: int = Field(default=300, alias="WAYBACKURLS_TIMEOUT")
+    max_concurrent_fetches: int = Field(default=3, alias="WAYBACKURLS_MAX_CONCURRENT")
+
+
+settings = Settings()
+
+
+class FetchResult(BaseModel):
+    """Model for fetch results."""
+
+    fetch_id: str
+    domain: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    status: str = "running"
+    urls: list[str] = []
+    total_urls: int = 0
+    stats: dict[str, Any] = {}
+    error: str | None = None
+
+
+# In-memory storage for fetch results
+fetch_results: dict[str, FetchResult] = {}
+active_fetches: set[str] = set()
+
+
+def analyze_urls(urls: list[str]) -> dict[str, Any]:
+    """Analyze fetched URLs and generate statistics."""
+    stats = {
+        "total": len(urls),
+        "by_extension": {},
+        "by_subdomain": {},
+        "by_path_depth": {},
+        "protocols": {"http": 0, "https": 0},
+        "with_params": 0,
+    }
+
+    for url in urls:
+        try:
+            parsed = urlparse(url)
+            
+            # Protocol stats
+            if parsed.scheme == "http":
+                stats["protocols"]["http"] += 1
+            elif parsed.scheme == "https":
+                stats["protocols"]["https"] += 1
+            
+            # Subdomain stats
+            domain = parsed.netloc
+            stats["by_subdomain"][domain] = stats["by_subdomain"].get(domain, 0) + 1
+            
+            # Extension stats
+            path = parsed.path
+            if "." in path:
+                ext = path.split(".")[-1].split("?")[0].split("#")[0].lower()
+                if ext and len(ext) <= 5:
+                    stats["by_extension"][ext] = stats["by_extension"].get(ext, 0) + 1
+            
+            # Path depth
+            depth = len([p for p in path.split("/") if p])
+            stats["by_path_depth"][depth] = stats["by_path_depth"].get(depth, 0) + 1
+            
+            # Parameters
+            if parsed.query:
+                stats["with_params"] += 1
+                
+        except Exception as e:
+            logger.debug(f"Error analyzing URL {url}: {e}")
+            continue
+
+    # Sort and limit top entries
+    stats["by_extension"] = dict(sorted(
+        stats["by_extension"].items(), 
+        key=lambda x: x[1], 
+        reverse=True
+    )[:20])
+    
+    stats["by_subdomain"] = dict(sorted(
+        stats["by_subdomain"].items(), 
+        key=lambda x: x[1], 
+        reverse=True
+    )[:20])
+    
+    stats["by_path_depth"] = dict(sorted(
+        stats["by_path_depth"].items(), 
+        key=lambda x: x[0]
+    ))
+
+    return stats
+
+
+async def run_waybackurls(
+    domain: str,
+    get_subs: bool = False,
+    no_subs: bool = False,
+    dates: bool = False,
+    timeout: int | None = None,
+) -> FetchResult:
+    """Execute waybackurls asynchronously."""
+    fetch_id = str(uuid.uuid4())[:8]
+    output_file = Path(settings.output_dir) / f"wayback_{fetch_id}.txt"
+
+    result = FetchResult(
+        fetch_id=fetch_id,
+        domain=domain,
+        started_at=datetime.now(),
+    )
+    fetch_results[fetch_id] = result
+    active_fetches.add(fetch_id)
+
+    # Build waybackurls command
+    # waybackurls accepts domains on stdin
+    cmd = ["waybackurls"]
+    
+    if get_subs:
+        cmd.append("-get-subs")
+    if no_subs:
+        cmd.append("-no-subs")
+    if dates:
+        cmd.append("-dates")
+
+    logger.info(f"Starting waybackurls fetch {fetch_id} for domain: {domain}")
+    logger.debug(f"Command: echo {domain} | {' '.join(cmd)}")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        # Send domain to stdin
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(input=domain.encode()),
+            timeout=float(timeout or settings.default_timeout),
+        )
+
+        result.completed_at = datetime.now()
+
+        # Parse output
+        stdout_text = stdout.decode()
+        if stdout_text.strip():
+            urls = [line.strip() for line in stdout_text.split("\n") if line.strip()]
+            result.urls = urls
+            result.total_urls = len(urls)
+            
+            # Save to file
+            output_file.write_text("\n".join(urls))
+            
+            # Generate statistics
+            result.stats = analyze_urls(urls)
+
+        stderr_text = stderr.decode()
+        if stderr_text:
+            logger.debug(f"Waybackurls stderr: {stderr_text}")
+
+        if process.returncode == 0:
+            result.status = "completed"
+            logger.info(f"Fetch {fetch_id} completed: {result.total_urls} URLs found")
+        else:
+            if result.total_urls > 0:
+                result.status = "completed"
+            else:
+                result.status = "failed"
+                result.error = stderr_text or "No output from waybackurls"
+                logger.error(f"Fetch {fetch_id} failed: {result.error}")
+
+    except asyncio.TimeoutError:
+        result.status = "timeout"
+        result.error = f"Fetch timed out after {timeout or settings.default_timeout} seconds"
+        result.completed_at = datetime.now()
+        logger.error(f"Fetch {fetch_id} timed out")
+
+    except Exception as e:
+        result.status = "error"
+        result.error = str(e)
+        result.completed_at = datetime.now()
+        logger.exception(f"Fetch {fetch_id} error: {e}")
+
+    finally:
+        active_fetches.discard(fetch_id)
+        fetch_results[fetch_id] = result
+
+    return result
+
+
+def format_fetch_summary(result: FetchResult, include_urls: bool = False, limit: int = 100) -> dict[str, Any]:
+    """Format fetch result for response."""
+    summary = {
+        "fetch_id": result.fetch_id,
+        "domain": result.domain,
+        "status": result.status,
+        "total_urls": result.total_urls,
+        "started_at": result.started_at.isoformat(),
+        "completed_at": result.completed_at.isoformat() if result.completed_at else None,
+        "stats": result.stats,
+        "error": result.error,
+    }
+    
+    if include_urls:
+        summary["urls"] = result.urls[:limit]
+        if len(result.urls) > limit:
+            summary["urls_truncated"] = f"Showing {limit} of {len(result.urls)} URLs"
+    
+    return summary
+
+
+# Create MCP server
+app = Server("waybackurls-mcp")
+
+
+@app.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available tools."""
+    return [
+        Tool(
+            name="fetch_wayback_urls",
+            description="Fetch all URLs from the Wayback Machine for a given domain. "
+            "Returns historical URLs that were archived for the domain.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "domain": {
+                        "type": "string",
+                        "description": "Domain to fetch URLs for (e.g., example.com)",
+                    },
+                    "get_subs": {
+                        "type": "boolean",
+                        "description": "Also fetch subdomains (e.g., *.example.com)",
+                        "default": False,
+                    },
+                    "no_subs": {
+                        "type": "boolean",
+                        "description": "Don't include subdomains, only the exact domain",
+                        "default": False,
+                    },
+                    "dates": {
+                        "type": "boolean",
+                        "description": "Show timestamps for when URLs were archived",
+                        "default": False,
+                    },
+                    "include_urls": {
+                        "type": "boolean",
+                        "description": "Include the actual URLs in the response (default: true)",
+                        "default": True,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of URLs to return in response (default: 100)",
+                        "default": 100,
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Timeout in seconds",
+                        "default": 300,
+                    },
+                },
+                "required": ["domain"],
+            },
+        ),
+        Tool(
+            name="get_fetch_results",
+            description="Retrieve results from a previous waybackurls fetch by fetch ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "fetch_id": {
+                        "type": "string",
+                        "description": "Fetch ID returned from a previous fetch",
+                    },
+                    "include_urls": {
+                        "type": "boolean",
+                        "description": "Include the actual URLs in the response",
+                        "default": True,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of URLs to return",
+                        "default": 100,
+                    },
+                },
+                "required": ["fetch_id"],
+            },
+        ),
+        Tool(
+            name="list_active_fetches",
+            description="List currently running waybackurls fetches.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Handle tool calls."""
+    try:
+        if name == "fetch_wayback_urls":
+            if len(active_fetches) >= settings.max_concurrent_fetches:
+                return [
+                    TextContent(
+                        type="text",
+                        text=f"Maximum concurrent fetches ({settings.max_concurrent_fetches}) reached. "
+                        f"Please wait for active fetches to complete.",
+                    )
+                ]
+
+            domain = arguments["domain"]
+            # Clean domain input
+            domain = domain.strip().lower()
+            if domain.startswith("http://") or domain.startswith("https://"):
+                domain = urlparse(domain).netloc
+
+            result = await run_waybackurls(
+                domain=domain,
+                get_subs=arguments.get("get_subs", False),
+                no_subs=arguments.get("no_subs", False),
+                dates=arguments.get("dates", False),
+                timeout=arguments.get("timeout"),
+            )
+
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        format_fetch_summary(
+                            result,
+                            include_urls=arguments.get("include_urls", True),
+                            limit=arguments.get("limit", 100),
+                        ),
+                        indent=2,
+                    ),
+                )
+            ]
+
+        elif name == "get_fetch_results":
+            fetch_id = arguments["fetch_id"]
+            result = fetch_results.get(fetch_id)
+
+            if result:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            format_fetch_summary(
+                                result,
+                                include_urls=arguments.get("include_urls", True),
+                                limit=arguments.get("limit", 100),
+                            ),
+                            indent=2,
+                        ),
+                    )
+                ]
+            else:
+                return [
+                    TextContent(type="text", text=f"Fetch '{fetch_id}' not found")
+                ]
+
+        elif name == "list_active_fetches":
+            active = [
+                {
+                    "fetch_id": fetch_id,
+                    "domain": fetch_results[fetch_id].domain,
+                    "started_at": fetch_results[fetch_id].started_at.isoformat(),
+                }
+                for fetch_id in active_fetches
+                if fetch_id in fetch_results
+            ]
+
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "active_fetches": active,
+                            "count": len(active),
+                            "max_concurrent": settings.max_concurrent_fetches,
+                        },
+                        indent=2,
+                    ),
+                )
+            ]
+
+        else:
+            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+    except Exception as e:
+        logger.exception(f"Error executing tool {name}: {e}")
+        return [TextContent(type="text", text=f"Error: {str(e)}")]
+
+
+@app.list_resources()
+async def list_resources() -> list[Resource]:
+    """List available resources."""
+    resources = []
+
+    for fetch_id, result in fetch_results.items():
+        if result.status == "completed":
+            resources.append(
+                Resource(
+                    uri=f"waybackurls://results/{fetch_id}",
+                    name=f"Wayback URLs: {result.domain} ({result.total_urls} URLs)",
+                    description=f"Fetched at {result.completed_at}",
+                    mimeType="text/plain",
+                )
+            )
+
+    return resources
+
+
+@app.read_resource()
+async def read_resource(uri: str) -> str:
+    """Read a resource."""
+    if uri.startswith("waybackurls://results/"):
+        fetch_id = uri.replace("waybackurls://results/", "")
+        result = fetch_results.get(fetch_id)
+        if result:
+            return "\n".join(result.urls)
+
+    return json.dumps({"error": "Resource not found"})
+
+
+async def main():
+    """Run the MCP server."""
+    logger.info("Starting Waybackurls MCP Server")
+    logger.info(f"Output directory: {settings.output_dir}")
+
+    # Ensure directories exist
+    Path(settings.output_dir).mkdir(parents=True, exist_ok=True)
+
+    async with stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Added support in tomnomnom's [waybackurls](https://github.com/tomnomnom/waybackurls) tool (4.3 stars)

- Add waybackurls-mcp MCP server for Wayback Machine URL fetching
- Implement 3 tools: fetch_wayback_urls, get_fetch_results, list_active_fetches
- Include URL analysis (extensions, subdomains, path depth, protocols)
- Add Docker configuration and documentation
- Update docker-compose.yml with waybackurls-mcp service
- Update main README with new server (25 MCPs total)


Verified with a Claude Desktop + working account on my Mac, attached screenshots.
### Before configuring the new MCP:
<img width="3024" height="1634" alt="image" src="https://github.com/user-attachments/assets/bb2cd235-a984-430c-98e7-3444846e4748" />

### After configuring the new MCP:
<img width="1938" height="1790" alt="image" src="https://github.com/user-attachments/assets/43055641-d258-4aa1-8c97-c9e427387850" />
