### PR TITLE
Add docker-compose validation workflow and fix missing paths

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -1,0 +1,60 @@
+# Validate Docker Compose Configuration
+#
+# This workflow ensures docker-compose.yml references only existing paths
+# and has valid syntax. Runs on PRs and pushes to catch issues early.
+
+name: Validate Docker Compose
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'docker-compose.yml'
+      - '**/Dockerfile'
+      - '.github/workflows/validate-compose.yml'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'docker-compose.yml'
+      - '**/Dockerfile'
+      - '.github/workflows/validate-compose.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate docker-compose syntax
+        run: docker compose config --quiet
+
+      - name: Verify all build contexts exist
+        run: |
+          echo "Checking that all build contexts exist..."
+
+          # Extract build context paths from docker-compose.yml
+          contexts=$(grep -E "^\s+context:" docker-compose.yml | sed 's/.*context:\s*//' | tr -d "'\"")
+
+          failed=0
+          for ctx in $contexts; do
+            if [ ! -d "$ctx" ]; then
+              echo "❌ Missing build context: $ctx"
+              failed=1
+            else
+              echo "✅ Found: $ctx"
+            fi
+          done
+
+          if [ $failed -eq 1 ]; then
+            echo ""
+            echo "::error::Some build contexts are missing. Please remove non-existent services from docker-compose.yml"
+            exit 1
+          fi
+
+          echo ""
+          echo "All build contexts exist!"
+
+      - name: Dry-run build (validate Dockerfiles)
+        run: docker compose build --dry-run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -461,35 +461,6 @@ services:
           memory: 512M
 
   # ===========================================================================
-  # Mobile Security
-  # ===========================================================================
-  mobsf-mcp:
-    build:
-      context: ./mobile-security/mobsf-mcp
-      dockerfile: Dockerfile
-    image: ghcr.io/fuzzinglabs/mobsf-mcp:latest
-    container_name: mobsf-mcp
-    environment:
-      - MOBSF_API_KEY=${MOBSF_API_KEY:-}
-      - MOBSF_URL=${MOBSF_URL:-http://mobsf:8000}
-    volumes:
-      - mobsf-uploads:/app/uploads
-    ports:
-      - "3008:3000"
-    networks:
-      - mcp-network
-    restart: unless-stopped
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
-
-  # ===========================================================================
   # Cloud Security
   # ===========================================================================
   trivy-mcp:
@@ -600,10 +571,6 @@ volumes:
   yara-output:
     driver: local
   yara-samples:
-    driver: local
-
-  # MobSF
-  mobsf-uploads:
     driver: local
 
   # Trivy


### PR DESCRIPTION
## Summary
- Add GitHub Action to validate docker-compose.yml on PRs and pushes
- Remove non-existent `mobsf-mcp` service from docker-compose.yml

## Validation Workflow
The new workflow (`validate-compose.yml`) runs on every PR/push that touches docker-compose.yml or Dockerfiles:

1. **Syntax check**: `docker compose config --quiet`
2. **Path verification**: Ensures all `context:` paths exist
3. **Dry-run build**: Validates all Dockerfiles can be parsed

This prevents issues like #1 and #3 from happening again.

## Test plan
- [x] `docker compose config` passes
- [x] `docker compose build --dry-run` succeeds
- [x] All 18 services validate correctly

Fixes #1
Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)