### PR TITLE
Fix: remove duplicate validate-compose job from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,16 +93,3 @@ jobs:
         run: |
           pytest tests/ -v --tb=short || true
 
-  # ===========================================================================
-  # Validate docker-compose
-  # ===========================================================================
-  validate-compose:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate docker-compose.yml
-        run: |
-          docker-compose config --quiet
-          echo "docker-compose.yml is valid"


### PR DESCRIPTION
## Summary
- Remove duplicate validate-compose job that used deprecated `docker-compose` (V1)
- The separate `validate-compose.yml` workflow already handles validation using `docker compose` (V2)

## Problem
The build workflow failed with exit code 127 because `docker-compose` is not available on GitHub runners (deprecated in favor of `docker compose`).

## Test plan
- [ ] Verify build workflow passes
- [ ] Verify validate-compose workflow still runs separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)