### PR TITLE
test: add 6 missing MCP servers to test suite

### DIFF
--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -24,6 +24,7 @@ MCP_SERVERS = [
     ("web-security", "nuclei-mcp"),
     ("web-security", "sqlmap-mcp"),
     ("web-security", "ffuf-mcp"),
+    ("web-security", "waybackurls-mcp"),
     ("binary-analysis", "binwalk-mcp"),
     ("binary-analysis", "yara-mcp"),
     ("binary-analysis", "capa-mcp"),
@@ -31,6 +32,11 @@ MCP_SERVERS = [
     ("cloud-security", "prowler-mcp"),
     ("exploitation", "searchsploit-mcp"),
     ("blockchain", "daml-viewer-mcp"),
+    ("blockchain", "medusa-mcp"),
+    ("blockchain", "solazy-mcp"),
+    ("fuzzing", "boofuzz-mcp"),
+    ("fuzzing", "dharma-mcp"),
+    ("secrets", "gitleaks-mcp"),
 ]
 
 # MCP servers that wrap external implementations (Dockerfile only, no server.py)


### PR DESCRIPTION
## Problem

Six MCP servers that have full `server.py` implementations were not included in the `MCP_SERVERS` test parametrization in `test_mcp_servers.py`. This means their imports, app configuration, and tool definitions were never validated by the test suite.

## Missing servers

| Category | Server |
|---|---|
| blockchain | medusa-mcp |
| blockchain | solazy-mcp |
| fuzzing | boofuzz-mcp |
| fuzzing | dharma-mcp |
| secrets | gitleaks-mcp |
| web-security | waybackurls-mcp |

## Fix

Added all six servers to the `MCP_SERVERS` list so they are covered by the existing parametrized test class (`TestMCPServer`).